### PR TITLE
Fix kahaDB path

### DIFF
--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -308,13 +308,6 @@ class mcollective::server(
     $auditlog_ensure = file
   }
 
-  # This assumes that both mcollective and logrotate descend from a common etc directory
-  file { "${etcdir}/../logrotate.d":
-    ensure  => directory,
-    owner   => 0,
-    group   => 0,
-    mode    => '0755',
-  }
   file { "${etcdir}/../logrotate.d/mcollective-auditlog":
     ensure  => $auditlog_ensure,
     owner   => 0,

--- a/templates/activemq.xml.erb
+++ b/templates/activemq.xml.erb
@@ -101,7 +101,7 @@
             http://activemq.apache.org/persistence.html 
         -->
         <persistenceAdapter>
-            <kahaDB directory="kahadb"/>
+            <kahaDB directory="data/kahadb"/>
         </persistenceAdapter>
 
 <% end -%>


### PR DESCRIPTION
default installation of activemq-5.9.1-2.el6.noarch from puppetlabs-deps repo on centos 6.6 with the activemq.xml.erb provided by this module produces misconfigured activemq.
with following error regarding kahadb
```
2015-02-16 15:18:27,193 [main           ] INFO  BrokerService                  - Using Persistence Adapter: KahaDBPersistenceAdapter[/usr/share/activemq/kahadb]
2015-02-16 15:18:27,195 [main           ] INFO  SharedFileLocker               - Database kahadb/lock is locked... waiting 10 seconds for the database to be unlocked. Reason: java.io.IOException: Failed to create directory 'kahadb'
```
because path /usr/share/activemq/kahadb is not writable by activemq user

with this change activemq can actually be started