### PR TITLE
Enhance sshkey support

### DIFF
--- a/files/sshkey/security/sshkey.ddl
+++ b/files/sshkey/security/sshkey.ddl
@@ -1,0 +1,9 @@
+metadata  :name        => 'sshkey',
+          :description => 'Security Plugin that uses ssh keys for signing',
+          :author      => 'Pieter Loubser <pieter.loubser@puppetlabs.com>',
+          :license     => 'ASL 2.0',
+          :version     => '0.5.0',
+          :url         => 'http://projects.puppetlabs.com/projects/mcollective-plugins/wiki',
+          :timeout     => 10
+
+requires :mcollective => '2.2.1'

--- a/files/sshkey/security/sshkey.rb
+++ b/files/sshkey/security/sshkey.rb
@@ -1,0 +1,383 @@
+module MCollective
+  module Security
+    # Configuration
+    #
+    # Client:
+    #   client.private_key                      : A private key used to sign requests with - defaults to ssh-agent
+    #   client.known_hosts                      : The known_hosts file to use - defaults to /home/callerid/.ssh/known_hosts
+    #   client.send_key                         : Send the client's public key with the request - doesn not send the key by default.
+    #                                             To send a key specify the key file to send.
+    #
+    # Server:
+    #   server.private_key                      : The private key used to sign replies with - Defaults to /etc/ssh/ssh_host_rsa_key * required
+    #   server.authorized_keys                  : The authorized_keys file to use - defaults to the caller's authorized_keys file in his home directory
+    #   server.send_key                         : Send the server's public key with the request - does not send the key by default.
+    #                                             To send a key specify the key file to send.
+    #
+    # Shared:
+    #   (client|server).publickey_dir          : Directory to store received keys - defaults to none
+    #   (client|server).learn_public_keys      : Allow writing public keys to publickey_dir - defaults to not sending.
+    #   (client|server).overwrite_stored_keys  : Overwrite received keys - defaults to false
+    class Sshkey < Base
+      gem 'sshkeyauth', '>= 0.0.4'
+
+      require 'ssh/key/signer'
+      require 'ssh/key/verifier'
+      require 'etc'
+
+      def initialize
+        @known_hosts_cache = {}
+        @known_hosts_mtime = 0
+        super
+      end
+
+      def decodemsg(msg)
+        body = Marshal.load(msg.payload)
+
+        if validrequest?(body)
+          body[:body] = Marshal.load(body[:body])
+          return body
+        else
+          nil
+        end
+      end
+
+      def encodereply(sender, msg, requestid, requestcallerid=nil)
+        serialized_msg = Marshal.dump(msg)
+        reply = create_reply(requestid, sender, serialized_msg)
+        reply[:serialized_data] = Marshal.dump(create_hash_fields(serialized_msg, reply[:msgtime], requestid))
+        reply[:hash] = makehash(reply[:serialized_data])
+
+        if server_key = lookup_config_option('send_key')
+          if File.exists?(server_key)
+            reply[:public_key] = load_key(server_key)
+          else
+            raise("Cannot create reply. sshkey.server.send_key set but key '%s' does not exist." % server_key)
+          end
+        end
+
+        Marshal.dump(reply)
+      end
+
+      def encoderequest(sender, msg, requestid, filter, target_agent, target_collective, ttl=60)
+        serialized_msg = Marshal.dump(msg)
+        req = create_request(requestid, filter, serialized_msg, @initiated_by, target_agent, target_collective, ttl)
+
+
+        if client_key = lookup_config_option('send_key')
+          if File.exists?(client_key)
+            req[:public_key] = load_key(client_key)
+          else
+            raise("Cannot create request. sshkey.client.send_key set but key '%s' does not exist." % client_key)
+          end
+        end
+
+        req[:serialized_data] = Marshal.dump(create_hash_fields(serialized_msg, req[:msgtime], requestid, ttl, callerid))
+        req[:hash] = makehash(req[:serialized_data])
+
+        Marshal.dump(req)
+      end
+
+      def validrequest?(req)
+        # Check if verification keys are correctly configured
+        valid_configuration?
+        # Check if key should be written to disk and write it
+        write_key_to_disk(req[:public_key], (req[:callerid] || req[:senderid]).split('=')[-1] ) if req[:public_key]
+
+        if @initiated_by == :client
+          Log.debug('Validating reply from node %s' % req[:senderid])
+          verifier = client_verifier(req[:senderid])
+        else
+          Log.debug('Validating request from client %s' % req[:callerid])
+          verifier = node_verifier(req[:callerid], (req[:agent] == 'registration'), req[:public_key])
+        end
+
+        signatures = Marshal.load(req[:hash])
+
+        if verifier.verify?(signatures, req[:serialized_data])
+          @stats.validated
+          return true
+        else
+          @stats.unvalidated
+          Log.debug('Received an invalid signature in message.')
+          raise SecurityValidationFailed
+        end
+      end
+
+      def callerid
+        'sshkey=%s' % (ENV['MCOLLECTIVE_SSH_CALLERID'] ? ENV['MCOLLECTIVE_SSH_CALLERID'] : Etc.getpwuid(Process.uid).name)
+      end
+
+      private
+
+      # Checks that publickey_dir and known_hosts|authorized_keys are not set at the same time.
+      def valid_configuration?
+        if @initiated_by == :client
+          if lookup_config_option('publickey_dir') && lookup_config_option('known_hosts')
+            raise('Both publickey_dir and known_hosts are defined in client config. Cannot lookup public key')
+          end
+        elsif @initiated_by == :node
+          if lookup_config_option('publickey_dir') && lookup_config_option('authorized_keys')
+            raise('Both publickey_dir and authorized_keys are defiend in server config. Cannot lookup public key')
+          end
+        end
+      end
+
+      # Checks if the attached public key needs to be stored locally
+      # Overwriting is disabled by default
+      # - The publickey_directory config option needs to be set before
+      #   the file will be written.
+      # - The directory must exist before writing.
+      # - The learn_public_keys configuration option must be enabled.
+      def write_key_to_disk(key, identity)
+
+        # Writing is disabled. Don't bother checking any other states.
+        return unless lookup_config_option('learn_public_keys') =~ /^1|y/
+
+        publickey_dir = lookup_config_option('publickey_dir')
+
+        unless publickey_dir
+          Log.info("Public key sent with request but no publickey_dir defined in configuration. Not writing key to disk.")
+          return
+        end
+
+        if File.directory?(publickey_dir)
+          if File.exists?(old_keyfile = File.join(publickey_dir, "#{identity}_pub.pem"))
+            old_key = File.read(old_keyfile).chomp
+
+            unless old_key == key
+              unless lookup_config_option('overwrite_stored_keys', 'n') =~ /^1|y/
+                Log.warn("Public key sent from '%s' does not match the stored key. Not overwriting." % identity)
+              else
+                Log.warn("Public key sent from '%s' does not match the stored key. Overwriting." % identity)
+                File.open(File.join(publickey_dir, "#{identity}_pub.pem"), 'w') { |f| f.puts key }
+              end
+            end
+          else
+            Log.debug("Discovered a new public key for '%s'. Writing to '%s'" % [identity, publickey_dir])
+            File.open(File.join(publickey_dir, "#{identity}_pub.pem"), 'w') { |f| f.puts key }
+          end
+        else
+          raise("Cannot write public key to '%s'. Directory does not exist." % publickey_dir)
+        end
+      end
+
+      # Fetches the correct configuration option for a client or a server
+      def lookup_config_option(opt, default = nil)
+        if @initiated_by == :client
+          result = @config.pluginconf.fetch("sshkey.client.#{opt}", default)
+
+          if result && ["authorized_keys", "private_key", "send_key", "publickey_dir", "known_hosts"].include?(opt)
+            return File.expand_path(result)
+          else
+            return result
+          end
+        elsif @initiated_by == :node
+          return @config.pluginconf.fetch("sshkey.server.#{opt}", default)
+        end
+      end
+
+      # Creates a hash of the fields used to sign a message
+      # Response messages use the msg, msgtime and requestid fields.
+      # Request messages use the same fields as response, but include
+      # ttl and callerid.
+      def create_hash_fields(msg, msgtime, requestid, ttl = nil, callerid = nil)
+        map = {:msg       => msg,
+               :msgtime   => msgtime,
+               :requestid => requestid}
+
+        # Check if this is a server hash
+        return map if (ttl == nil && callerid == nil)
+
+        map[:ttl] = ttl
+        map[:callerid] = callerid
+
+        map
+      end
+
+      # Adds a key to a signer object and disables ssh-agent
+      def add_key_to_signer(signer, key, passphrase=nil)
+        if passphrase != nil
+          signer.add_key_file(key, passphrase)
+        else
+          signer.add_key_file(key)
+        end
+        signer.use_agent = false
+      end
+
+      # Creates a signed hash of fields using the node's private key
+      def makehash(data)
+        signer = SSH::Key::Signer.new
+
+        # Check if the client is signing its request with a predefined
+        # private key. If this is the case, disable ssh-agent.
+        if @initiated_by == :client
+          if ENV['MCOLLECTIVE_SSH_KEY']
+            add_key_to_signer(signer, ENV['MCOLLECTIVE_SSH_KEY'], ENV['MCOLLECTIVE_SSH_KEY_PASSPHRASE'])
+          elsif private_key = lookup_config_option('private_key')
+            unless File.exists?(private_key)
+              raise("Cannot sign request - private key not found: '%s'" % private_key)
+            else
+              add_key_to_signer(signer, private_key, lookup_config_option('private_key_passphrase'))
+            end
+          end
+        elsif @initiated_by == :node
+          if private_key = lookup_config_option('private_key')
+            add_key_to_signer(signer, private_key)
+          else
+            # First try and default to ssh_host_dsa_key
+            if File.exists?(private_key = '/etc/ssh/ssh_host_dsa_key')
+              add_key_to_signer(signer, private_key)
+            # If that fails, try ssh_host_rsa_key
+            elsif File.exists?(private_key = '/etc/ssh/ssh_host_rsa_key')
+              add_key_to_signer(signer, private_key)
+            else
+              raise("Cannot sign reply - private key not found: 's'" % private_key)
+            end
+          end
+        end
+
+        # Default to using ssh-agent for key signing
+        signatures = signer.sign(data).collect { |s| s.signature }
+        Marshal.dump(signatures)
+      end
+
+      #Returns the contents of a key file on disk
+      def load_key(key)
+        if File.exists?(key)
+          return File.read(key).strip
+        else
+          nil
+        end
+      end
+
+      # Looks for a specific key in  known hosts file
+      def find_key_in_known_hosts(hostname, known_hosts)
+        parse_known_hosts_file known_hosts
+        key = @known_hosts_cache[hostname]
+
+        unless key
+          Log.warn("Could not find a key for host '%s' in file '%s'" % [hostname, known_hosts])
+          raise SecurityValidationFailed
+        end
+
+        key
+      end
+
+      # This should be safe, as we parse the known hosts file only in the client...
+      def parse_known_hosts_file(known_hosts)
+        if File.exists?(known_hosts)
+          known_hosts_mtime = File.mtime(known_hosts).to_i
+          return if known_hosts_mtime == @known_hosts_mtime
+          File.read(known_hosts).each_line do |line|
+            next if line =~ /^#/
+            fields = line.split
+            next if fields.count < 3
+            key = fields[-2] << ' ' << fields[-1]
+            fields[0].split(',').each do |host|
+              @known_hosts_cache[host] = key
+            end
+          end
+          @known_hosts_mtime = known_hosts_mtime
+        else
+          @known_hosts_mtime = 0
+          @known_hosts_cache = {}
+        end
+      end
+
+      # Create a client verifier object which uses the correct public key
+      def client_verifier(senderid)
+        verifier = SSH::Key::Verifier.new(senderid)
+        verifier.use_authorized_keys = false
+
+        if publickey_dir = lookup_config_option('publickey_dir')
+          Log.debug("Using public key directory: '%s'" % publickey_dir)
+          verifier.add_public_key_data(find_shared_public_key(publickey_dir, senderid))
+
+        elsif (known_hosts = lookup_config_option('known_hosts'))
+          Log.debug("Using custom known_hosts file: '%s'" % known_hosts)
+          verifier.add_public_key_data(find_key_in_known_hosts(senderid, known_hosts))
+
+        elsif (authorized_keys = lookup_config_option('authorized_keys'))
+          Log.debug("Found custom authorized_keys file: '%s'" % authorized_keys)
+          verifier.authorized_keys_file = authorized_keys
+          verifier.use_authorized_keys = true
+
+        else
+          begin
+            user = Etc.getpwuid(Process.uid).name
+            known_hosts = File.join(Etc.getpwnam(user).dir, '.ssh', 'known_hosts')
+            Log.debug("Using default known_hosts file for user '%s': ''" % [user, known_hosts])
+            verifier.add_public_key_data(find_key_in_known_hosts(senderid, "%s" % known_hosts))
+          rescue => e
+            raise("Cannot find known_hosts file for user '%s': '%s'" % [user, known_hosts])
+          end
+        end
+
+        verifier.use_agent = false
+
+        verifier
+      end
+
+      # Looks for a public key in a shared directory
+      def find_shared_public_key(dir, id)
+        unless File.directory?(dir)
+          raise("Cannot read shared public key directory: '%s'" % dir)
+        end
+
+        if File.exists?(key_file = File.join(dir, "#{id}_pub.pem"))
+          return File.read(key_file)
+        else
+          Log.warn("Cannot find public key for id '%s': '%s'" % [id, File.join(dir, "#{id}_pub.pem")])
+          raise SecurityValidationFailed
+        end
+      end
+
+      # Create a node verifier object which uses the correct public key
+      def node_verifier(callerid, registration = false, pubkey = nil)
+        user = callerid.split('=')[-1]
+        verifier = SSH::Key::Verifier.new(user)
+        verifier.use_agent = false
+
+        # Here we deal with the special case where a registration message
+        # is being validated. send_key has to be defined in the configuration.
+        # TODO : This is a stop gap measure we should remove when we fix
+        #        registration
+        if registration && pubkey
+          Log.debug("Found registration message. Using sender's public key")
+          verifier.add_public_key_data(pubkey)
+          verifier.use_authorized_keys = false
+
+        elsif registration && !pubkey
+          Log.warn("Cannot verify registration request. Server did not send its public key")
+          raise SecurityValidationFailed
+
+        elsif publickey_dir = lookup_config_option('publickey_dir')
+          if File.directory?(publickey_dir)
+            Log.debug("Found shared public key directory: '%s'" % publickey_dir)
+            verifier.add_public_key_data(find_shared_public_key(publickey_dir, user))
+            verifier.use_authorized_keys = false
+          else
+            raise("Public key directory '%s' does not exist" % publickey_dir)
+          end
+
+        elsif (authorized_keys = lookup_config_option('authorized_keys'))
+          authorized_keys = authorized_keys.sub('%u') { |c| user }
+          Log.debug("Found custom authorized_keys file: '%s'" % authorized_keys)
+          verifier.authorized_keys_file = authorized_keys
+
+        else
+          begin
+            authorized_keys = File.join(Etc.getpwnam(user).dir, '.ssh', 'authorized_keys')
+            Log.debug("No authorized_keys file or publickey_dir specified. Using '%s'" % authorized_keys)
+            verifier.authorized_keys_file = authorized_keys
+          rescue => e
+            raise("Cannot find authorized_keys file for user '%s': '%s'" % [user, authorized_keys])
+          end
+        end
+
+        verifier
+      end
+    end
+  end
+end

--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -53,10 +53,6 @@
 #    Max size in bytes for log files before rotation happens.
 #    Default: 2097152 (2mb)
 #
-# [*sshkey_known_hosts*]
-#    Defines a known hosts file for use instead of ~/.ssh/known_hosts
-#    Default: undefined  (only matters if security_provider is sshkey)
-#
 # [*disc_method*]
 #    Defines the default discovery method to use
 #    Default: mc
@@ -68,6 +64,20 @@
 # [*da_threshold*]
 #    Defines the threshold used to determine when to use direct addressing
 #    Default: 10
+#
+# [*sshkey_private_key*]
+#    A private key used to sign requests with
+#    Default: undefined  (only matters if security_provider is sshkey)
+#    When undefined, sshkey uses the ssh-agent to find a key
+#
+# [*sshkey_known_hosts*]
+#    A known_hosts file
+#    Default: undefined  (only matters if security_provider is sshkey)
+#    When undefined, sshkey uses /home/$USER/.ssh/known_hosts which is the same as OpenSSH by default
+#
+# [*sshkey_send_key*]
+#    Send the specified public key along with the request for dynamic key management
+#    Default: undefined  (only matters if security_provider is sshkey)
 #
 # === Variables
 #
@@ -101,6 +111,20 @@
 #   Valid to put in the 'caller' field of each request.
 #   Values: uid (default), gid, user, group, identity
 #
+# [*sshkey_publickey_dir*]
+#    Defines a directory to store received sshkey-based keys
+#    Default: undefined  (only matters if security_provider is sshkey)
+#
+# [*sshkey_learn_public_keys*]
+#    Allows the sshkey plugin to write out sent keys to [*sshkey_publickey_dir*]
+#    Default: Do not send  (only matters if security_provider is sshkey)
+#    Values: true,false (default)
+#
+# [*sshkey_overwrite_stored_keys*]
+#    In the event of a key mismatch, overwrite stored key data
+#    Default: Do not overwrite  (only matters if security_provider is sshkey)
+#    Values: true, false (default)
+#
 # === Examples
 #
 #  class { 'mcollective::client':
@@ -124,7 +148,6 @@ class mcollective::client(
 
   # Package update?
   $version            = 'latest',
-  $sshkey_known_hosts = undef,
 
   # Logging
   $logfile      = $mcollective::params::logfile,
@@ -136,6 +159,14 @@ class mcollective::client(
   $disc_method  = 'mc',
   $disc_options = undef,
   $da_threshold = '10',
+  
+  # Authentication
+  $sshkey_private_key           = undef,
+  $sshkey_known_hosts           = undef,
+  $sshkey_send_key              = undef,
+  $sshkey_publickey_dir         = $mcollective::sshkey_publickey_dir,
+  $sshkey_learn_public_keys     = $mcollective::sshkey_learn_public_keys,
+  $sshkey_overwrite_stored_keys = $mcollective::sshkey_overwrite_stored_keys,
 )
 inherits mcollective {
 

--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -130,6 +130,18 @@
 #    Default: Do not overwrite  (only matters if security_provider is sshkey)
 #    Values: true, false (default)
 #
+# [*trusted_ssl_server_cert*]
+#   The path to your trusted server certificate. (Only used with trusted connector_ssl_type)
+#   Default: Re-use your puppet CA infrastructure
+#
+# [*trusted_ssl_server_key*]
+#   The path to your private key used with the trusted server certificate. (Only used with trusted connector_ssl_type)
+#   Default: Re-use your puppet CA infrastructure
+#
+# [*trusted_ssl_ca_cert*]
+#   The path to your trusted certificate authority certificate. (Only used with trusted connector_ssl_type)
+#   Default: Re-use your puppet CA infrastructure
+#
 # === Examples
 #
 #  class { 'mcollective::client':
@@ -145,11 +157,14 @@
 #
 class mcollective::client(
   # This value can be overridden in Hiera or through class parameters
-  $unix_group   = 'wheel',
-  $etcdir       = $mcollective::etcdir,
-  $hosts        = $mcollective::hosts,
-  $collectives  = $mcollective::collectives,
-  $package      = $mcollective::params::client_package_name,
+  $unix_group                   = 'wheel',
+  $etcdir                       = $mcollective::etcdir,
+  $hosts                        = $mcollective::hosts,
+  $collectives                  = $mcollective::collectives,
+  $package                      = $mcollective::params::client_package_name,
+  $trusted_ssl_server_cert      = $mcollective::trusted_ssl_server_cert,
+  $trusted_ssl_server_key       = $mcollective::trusted_ssl_server_key,
+  $trusted_ssl_ca_cert          = $mcollective::trusted_ssl_ca_cert,
 
   # Package update?
   $version            = 'latest',

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -166,7 +166,9 @@ class mcollective(
     }
     
     # Create parent directory
-    file { ["${libdir}/mcollective", "${libdir}/mcollective/security"]:
+    file { ["${libdir}",
+            "${libdir}/mcollective",
+            "${libdir}/mcollective/security", ]:
       ensure  => directory,
       owner   => 0,
       group   => 0,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -209,5 +209,14 @@ class mcollective(
       mode    => '0444',
       source  => 'puppet:///modules/mcollective/sshkey/security/sshkey.ddl',
     }
+    
+    if( $sshkey_publickey_dir )
+      file { $sshkey_publickey_dir:
+       ensure => directory,
+       owner  => 0,
+       group  => 0,
+       mode   => '0666',
+      }
+    }
   }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -210,7 +210,7 @@ class mcollective(
       source  => 'puppet:///modules/mcollective/sshkey/security/sshkey.ddl',
     }
     
-    if( $sshkey_publickey_dir )
+    if( $sshkey_publickey_dir ) {
       file { $sshkey_publickey_dir:
        ensure => directory,
        owner  => 0,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -134,11 +134,6 @@ class mcollective(
   if( $security_provider == 'psk' ) {
     validate_re( $psk_key, '^\S{20}', 'Please use a longer string of non-whitespace characters for the pre-shared key' )
   }
-  
-  if( $security_provider == 'sshkey' ) {
-    validate_bool( $sshkey_learn_public_keys )
-    validate_bool( $sshkey_overwrite_stored_keys )
-  }
 
   # Set the appropriate default port based on whether SSL is enabled
   if( $port != undef ) {

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -166,7 +166,7 @@ class mcollective(
     }
     
     # Create parent directory
-    file { "${libdir}/mcollective/security":
+    file { ["${libdir}/mcollective", "${libdir}/mcollective/security"]:
       ensure  => directory,
       owner   => 0,
       group   => 0,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -57,6 +57,20 @@
 # [*registerinterval*]
 #   How often to resend registration information in seconds. Default 600
 #
+# [*sshkey_publickey_dir*]
+#    Defines a directory to store received sshkey-based keys
+#    Default: undefined  (only matters if security_provider is sshkey)
+#
+# [*sshkey_learn_public_keys*]
+#    Allows the sshkey plugin to write out sent keys to [*sshkey_publickey_dir*]
+#    Default: Do not send  (only matters if security_provider is sshkey)
+#    Values: true,false (default)
+#
+# [*sshkey_overwrite_stored_keys*]
+#    In the event of a key mismatch, overwrite stored key data
+#    Default: Do not overwrite  (only matters if security_provider is sshkey)
+#    Values: true, false (default)
+#
 # === Examples
 #
 # node default {
@@ -82,22 +96,26 @@ class mcollective(
   $stomp_version        =  'latest',
 
   # Puppet v3 will look for values in Hiera before falling back to defaults defined here
-  $server_user          =  'server',
-  $server_password      = undef,
-  $client_user          =  'client',
-  $client_password      = undef,
-  $broker_user          =  'admin',
-  $broker_password      = undef,
-  $connector            = 'activemq',
-  $connector_ssl        = false,
-  $connector_ssl_type   = 'anonymous',
-  $port                 = undef,
-  $hosts,               # array required - no default value
-  $collectives          = ['mcollective'],
-  $registerinterval     = 600,
-  $security_provider    = 'psk',
-  $psk_key              = undef,   # will be checked if provider = psk
-  $psk_callertype       = 'uid',
+  $server_user                  =  'server',
+  $server_password              = undef,
+  $client_user                  =  'client',
+  $client_password              = undef,
+  $broker_user                  =  'admin',
+  $broker_password              = undef,
+  $connector                    = 'activemq',
+  $connector_ssl                = false,
+  $connector_ssl_type           = 'anonymous',
+  $port                         = undef,
+  $hosts,                       # array required - no default value
+  $collectives                  = ['mcollective'],
+  $registerinterval             = 600,
+  $security_provider            = 'psk',
+  $psk_key                      = undef,   # will be checked if provider = psk
+  $psk_callertype               = 'uid',
+  $sshkey_publickey_dir         = undef,
+  $sshkey_learn_public_keys     = false,
+  $sshkey_overwrite_stored_keys = false,
+  
 )
   inherits mcollective::params {
 
@@ -115,6 +133,11 @@ class mcollective(
 
   if( $security_provider == 'psk' ) {
     validate_re( $psk_key, '^\S{20}', 'Please use a longer string of non-whitespace characters for the pre-shared key' )
+  }
+  
+  if( $security_provider == 'sshkey' ) {
+    validate_bool( $sshkey_learn_public_keys )
+    validate_bool( $sshkey_overwrite_stored_keys )
   }
 
   # Set the appropriate default port based on whether SSL is enabled

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -156,4 +156,38 @@ class mcollective(
       }
     }
   }
+  
+  # Setup the sshkey security plugin for the client and server modules
+  if( $mcollective::security_provider == 'sshkey' ) {
+    # Install the sshkeyauth rubygem to the ruby AIO environment
+    package { 'sshkeyauth':
+      ensure   =>  'present',
+      provider =>  'puppet_gem',
+    }
+    
+    # Create parent directory
+    file { "${libdir}/mcollective/security":
+      ensure  => directory,
+      owner   => 0,
+      group   => 0,
+      mode    => '0755',
+    }
+
+    #Setup sshkey plugin files
+    file { "${libdir}/mcollective/security/sshkey.rb":
+      ensure  => file,
+      owner   => 0,
+      group   => 0,
+      mode    => '0444',
+      source  => 'puppet:///modules/mcollective/sshkey/security/sshkey.rb',
+    }
+
+    file { "${libdir}/mcollective/security/sshkey.ddl":
+      ensure  => file,
+      owner   => 0,
+      group   => 0,
+      mode    => '0444',
+      source  => 'puppet:///modules/mcollective/sshkey/security/sshkey.ddl',
+    }
+  }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -71,6 +71,18 @@
 #    Default: Do not overwrite  (only matters if security_provider is sshkey)
 #    Values: true, false (default)
 #
+# [*trusted_ssl_server_cert*]
+#   The path to your trusted server certificate. (Only used with trusted connector_ssl_type)
+#   Default: Re-use your puppet CA infrastructure
+#
+# [*trusted_ssl_server_key*]
+#   The path to your private key used with the trusted server certificate. (Only used with trusted connector_ssl_type)
+#   Default: Re-use your puppet CA infrastructure
+#
+# [*trusted_ssl_ca_cert*]
+#   The path to your trusted certificate authority certificate. (Only used with trusted connector_ssl_type)
+#   Default: Re-use your puppet CA infrastructure
+#
 # === Examples
 #
 # node default {
@@ -115,6 +127,9 @@ class mcollective(
   $sshkey_publickey_dir         = undef,
   $sshkey_learn_public_keys     = false,
   $sshkey_overwrite_stored_keys = false,
+  $trusted_ssl_server_cert      = "${::ssldir}/certs/${::clientcert}.pem",
+  $trusted_ssl_server_key       = "${::ssldir}/private_keys/${::clientcert}.pem",
+  $trusted_ssl_ca_cert          = "${::ssldir}/certs/ca.pem",
   
 )
   inherits mcollective::params {

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -159,7 +159,7 @@ class mcollective::server(
   $audit_logfile                = undef,
   $authorization_enable         = undef,
   $authorization_default_policy = undef,
-  $ssh_authorized_keys          = undef,
+  $sshkey_authorized_keys       = undef,
 
   # Logging
   $logrotate_directory          = $mcollective::params::logrotate_directory,

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -95,6 +95,15 @@
 #    Defines a authorized keys file for use instead of ~/.ssh/authorized_keys
 #    Default: undefined  (only matters if security_provider is sshkey)
 #
+# [*sshkey_private_key*]
+#    The private key used to sign replies to mcollective requests 
+#    Default: undefined  (only matters if security_provider is sshkey)
+#    This uses /etc/ssh/ssh_host_rsa_key if undefined
+#
+# [*sshkey_send_key*]
+#    Send the specified public key back along with the reply for dynamic key management
+#    Default: undefined  (only matters if security_provider is sshkey)
+#
 # === Variables
 #
 # This class makes use of these variables from base mcollective class
@@ -128,6 +137,32 @@
 # [*registerinterval*]
 #   How often to resend registration information in seconds. Default 600
 #
+# [*sshkey_publickey_dir*]
+#    Defines a directory to store received sshkey-based keys
+#    Default: undefined  (only matters if security_provider is sshkey)
+#
+# [*sshkey_learn_public_keys*]
+#    Allows the sshkey plugin to write out sent keys to [*sshkey_publickey_dir*]
+#    Default: Do not send  (only matters if security_provider is sshkey)
+#    Values: true,false (default)
+#
+# [*sshkey_overwrite_stored_keys*]
+#    In the event of a key mismatch, overwrite stored key data
+#    Default: Do not overwrite  (only matters if security_provider is sshkey)
+#    Values: true, false (default)
+#
+# [*trusted_ssl_server_cert*]
+#   The path to your trusted server certificate. (Only used with trusted connector_ssl_type)
+#   Default: Re-use your puppet CA infrastructure
+#
+# [*trusted_ssl_server_key*]
+#   The path to your private key used with the trusted server certificate. (Only used with trusted connector_ssl_type)
+#   Default: Re-use your puppet CA infrastructure
+#
+# [*trusted_ssl_ca_cert*]
+#   The path to your trusted certificate authority certificate. (Only used with trusted connector_ssl_type)
+#   Default: Re-use your puppet CA infrastructure
+#
 # === Examples
 #
 #  class { 'mcollective::server':
@@ -151,6 +186,9 @@ class mcollective::server(
   $enable                       = true,
   $hosts                        = $mcollective::hosts,
   $collectives                  = $mcollective::collectives,
+  $trusted_ssl_server_cert      = $mcollective::trusted_ssl_server_cert,
+  $trusted_ssl_server_key       = $mcollective::trusted_ssl_server_key,
+  $trusted_ssl_ca_cert          = $mcollective::trusted_ssl_ca_cert,
 
   # Authorization
   $allow_managed_resources      = true,
@@ -159,7 +197,14 @@ class mcollective::server(
   $audit_logfile                = undef,
   $authorization_enable         = undef,
   $authorization_default_policy = undef,
-  $ssh_authorized_keys          = undef,
+  
+  # Authentication
+  $sshkey_authorized_keys       = undef,
+  $sshkey_private_key           = undef,
+  $sshkey_send_key              = undef,
+  $sshkey_publickey_dir         = $mcollective::sshkey_publickey_dir,
+  $sshkey_learn_public_keys     = $mcollective::sshkey_learn_public_keys,
+  $sshkey_overwrite_stored_keys = $mcollective::sshkey_overwrite_stored_keys,
 
   # Logging
   $logrotate_directory          = $mcollective::params::logrotate_directory,

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -95,6 +95,15 @@
 #    Defines a authorized keys file for use instead of ~/.ssh/authorized_keys
 #    Default: undefined  (only matters if security_provider is sshkey)
 #
+# [*sshkey_private_key*]
+#    The private key used to sign replies to mcollective requests 
+#    Default: undefined  (only matters if security_provider is sshkey)
+#    This uses /etc/ssh/ssh_host_rsa_key if undefined
+#
+# [*sshkey_send_key*]
+#    Send the specified public key back along with the reply for dynamic key management
+#    Default: undefined  (only matters if security_provider is sshkey)
+#
 # === Variables
 #
 # This class makes use of these variables from base mcollective class
@@ -128,6 +137,20 @@
 # [*registerinterval*]
 #   How often to resend registration information in seconds. Default 600
 #
+# [*sshkey_publickey_dir*]
+#    Defines a directory to store received sshkey-based keys
+#    Default: undefined  (only matters if security_provider is sshkey)
+#
+# [*sshkey_learn_public_keys*]
+#    Allows the sshkey plugin to write out sent keys to [*sshkey_publickey_dir*]
+#    Default: Do not send  (only matters if security_provider is sshkey)
+#    Values: true,false (default)
+#
+# [*sshkey_overwrite_stored_keys*]
+#    In the event of a key mismatch, overwrite stored key data
+#    Default: Do not overwrite  (only matters if security_provider is sshkey)
+#    Values: true, false (default)
+#
 # === Examples
 #
 #  class { 'mcollective::server':
@@ -159,7 +182,14 @@ class mcollective::server(
   $audit_logfile                = undef,
   $authorization_enable         = undef,
   $authorization_default_policy = undef,
+  
+  # Authentication
   $sshkey_authorized_keys       = undef,
+  $sshkey_private_key           = undef,
+  $sshkey_send_key              = undef,
+  $sshkey_publickey_dir         = $mcollective::sshkey_publickey_dir,
+  $sshkey_learn_public_keys     = $mcollective::sshkey_learn_public_keys,
+  $sshkey_overwrite_stored_keys = $mcollective::sshkey_overwrite_stored_keys,
 
   # Logging
   $logrotate_directory          = $mcollective::params::logrotate_directory,

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -151,6 +151,18 @@
 #    Default: Do not overwrite  (only matters if security_provider is sshkey)
 #    Values: true, false (default)
 #
+# [*trusted_ssl_server_cert*]
+#   The path to your trusted server certificate. (Only used with trusted connector_ssl_type)
+#   Default: Re-use your puppet CA infrastructure
+#
+# [*trusted_ssl_server_key*]
+#   The path to your private key used with the trusted server certificate. (Only used with trusted connector_ssl_type)
+#   Default: Re-use your puppet CA infrastructure
+#
+# [*trusted_ssl_ca_cert*]
+#   The path to your trusted certificate authority certificate. (Only used with trusted connector_ssl_type)
+#   Default: Re-use your puppet CA infrastructure
+#
 # === Examples
 #
 #  class { 'mcollective::server':
@@ -174,6 +186,9 @@ class mcollective::server(
   $enable                       = true,
   $hosts                        = $mcollective::hosts,
   $collectives                  = $mcollective::collectives,
+  $trusted_ssl_server_cert      = $mcollective::trusted_ssl_server_cert,
+  $trusted_ssl_server_key       = $mcollective::trusted_ssl_server_key,
+  $trusted_ssl_ca_cert          = $mcollective::trusted_ssl_ca_cert,
 
   # Authorization
   $allow_managed_resources      = true,

--- a/manifests/userconfig.pp
+++ b/manifests/userconfig.pp
@@ -210,7 +210,7 @@ define mcollective::userconfig(
   
   exec { "create-public-${user}":
     path    => '/usr/bin:/usr/local/bin',
-    command => "openssl rsa -in ${private_key} -pubout -out ${public_key}",
+    command => "ssh-keygen -y -f ${private_key} > ${public_key}",
     unless  => "/usr/bin/test -e ${public_key}",
     require => Exec["create-private-${user}"],
   }

--- a/manifests/userconfig.pp
+++ b/manifests/userconfig.pp
@@ -107,12 +107,24 @@
 #   The path to your trusted server certificate. (Only used with trusted connector_ssl_type)
 #   Default: Re-use your puppet CA infrastructure, captured to your home directory at .puppet/ssl/certs/
 #
+# [*trusted_ssl_server_cert_content*]
+#   The content of your trusted server certificate. (Only used with trusted connector_ssl_type)
+#   Default: Re-use your puppet CA infrastructure, captured to your home directory at .puppet/ssl/certs/
+#
 # [*trusted_ssl_server_key*]
 #   The path to your private key used with the trusted server certificate. (Only used with trusted connector_ssl_type)
 #   Default: Re-use your puppet CA infrastructure, captured to your home directory at .puppet/ssl/private_keys/
 #
+# [*trusted_ssl_server_key_content*]
+#   The content of your private key used with the trusted server certificate. (Only used with trusted connector_ssl_type)
+#   Default: Re-use your puppet CA infrastructure, captured to your home directory at .puppet/ssl/private_keys/
+#
 # [*trusted_ssl_ca_cert*]
 #   The path to your trusted certificate authority certificate. (Only used with trusted connector_ssl_type)
+#   Default: Re-use your puppet CA infrastructure, captured to your home directory at .puppet/ssl/certs/
+#
+# [*trusted_ssl_ca_cert_content*]
+#   The content of your trusted certificate authority certificate. (Only used with trusted connector_ssl_type)
 #   Default: Re-use your puppet CA infrastructure, captured to your home directory at .puppet/ssl/certs/
 #
 # === Examples
@@ -134,12 +146,15 @@ define mcollective::userconfig(
   $filename     = '.mcollective',
 
   # This value can be overridden in Hiera or through class parameters
-  $etcdir                       = $mcollective::etcdir,
-  $hosts                        = $mcollective::hosts,
-  $collectives                  = $mcollective::collectives,
-  $trusted_ssl_server_cert      = undef,
-  $trusted_ssl_server_key       = undef,
-  $trusted_ssl_ca_cert          = undef,
+  $etcdir                           = $mcollective::etcdir,
+  $hosts                            = $mcollective::hosts,
+  $collectives                      = $mcollective::collectives,
+  $trusted_ssl_server_cert          = undef,
+  $trusted_ssl_server_cert_content  = undef,
+  $trusted_ssl_server_key           = undef,
+  $trusted_ssl_server_key_content   = undef,
+  $trusted_ssl_ca_cert              = undef,
+  $trusted_ssl_ca_cert_content      = undef,
 
   # Logging
   $logger_type  = $mcollective::client::logger_type,
@@ -183,21 +198,21 @@ define mcollective::userconfig(
       owner   =>  $user,
       group   =>  $group,
       mode    =>  '0500',
-      source  =>  pick($trusted_ssl_server_cert,$mcollective::trusted_ssl_server_cert),
+      content  =>  pick($trusted_ssl_server_cert_content,file($trusted_ssl_server_cert),file($mcollective::trusted_ssl_server_cert)),
     }
     file {$trusted_ssl_server_key_real:
       ensure  =>  file,
       owner   =>  $user,
       group   =>  $group,
       mode    =>  '0500',
-      source  =>  pick($trusted_ssl_server_key,$mcollective::trusted_ssl_server_key),
+      content  =>  pick($trusted_ssl_server_key_content,file($trusted_ssl_server_key),file($mcollective::trusted_ssl_server_key)),
     }
     file {$trusted_ssl_ca_cert_real:
       ensure  =>  file,
       owner   =>  $user,
       group   =>  $group,
       mode    =>  '0500',
-      source  =>  pick($trusted_ssl_ca_cert,$mcollective::trusted_ssl_ca_cert),
+      content  =>  pick($trusted_ssl_ca_cert_content,file($trusted_ssl_ca_cert),file($mcollective::trusted_ssl_ca_cert)),
     }
   }
   

--- a/manifests/userconfig.pp
+++ b/manifests/userconfig.pp
@@ -153,7 +153,7 @@ define mcollective::userconfig(
   }
   
   # Create the parent default directory if needed
-  if( !$sshkey_private_key || !$sshkey_send_key){
+  if( !$sshkey_private_key or !$sshkey_send_key){
     file {"${homepath}/.mcollective.d":
       ensure => 'directory',
       owner  => $user,

--- a/manifests/userconfig.pp
+++ b/manifests/userconfig.pp
@@ -38,7 +38,7 @@
 #
 # === Variables
 #
-# This class makes use of these variables from base mcollective class
+# This class makes use of these variables from base mcollective class and client mcollective class
 #
 # [*client_user*]
 #   The username clients will use to authenticate.
@@ -69,6 +69,34 @@
 #   Valid to put in the 'caller' field of each request.
 #   Values: uid (default), gid, user, group, identity
 #
+# [*sshkey_publickey_dir*]
+#    Defines a directory to store received sshkey-based keys
+#    Default: undefined  (only matters if security_provider is sshkey)
+#
+# [*sshkey_learn_public_keys*]
+#    Allows the sshkey plugin to write out sent keys to [*sshkey_publickey_dir*]
+#    Default: Do not send  (only matters if security_provider is sshkey)
+#    Values: true,false (default)
+#
+# [*sshkey_overwrite_stored_keys*]
+#    In the event of a key mismatch, overwrite stored key data
+#    Default: Do not overwrite  (only matters if security_provider is sshkey)
+#    Values: true, false (default)
+#
+# [*sshkey_private_key*]
+#    A private key used to sign requests with
+#    Default: undefined  (only matters if security_provider is sshkey)
+#    When undefined, sshkey uses the ssh-agent to find a key
+#
+# [*sshkey_known_hosts*]
+#    A known_hosts file
+#    Default: undefined  (only matters if security_provider is sshkey)
+#    When undefined, sshkey uses /home/$USER/.ssh/known_hosts which is the same as OpenSSH by default
+#
+# [*sshkey_send_key*]
+#    Send the specified public key along with the request for dynamic key management
+#    Default: undefined  (only matters if security_provider is sshkey)
+#
 # === Examples
 #
 #  mcollective::userconfig { 'jorhett':
@@ -95,6 +123,14 @@ define mcollective::userconfig(
   # Logging
   $logger_type  = $mcollective::client::logger_type,
   $log_level    = $mcollective::client::log_level,
+  
+  # Authentication
+  $sshkey_private_key           = $mcollective::client::sshkey_private_key,
+  $sshkey_known_hosts           = $mcollective::client::sshkey_known_hosts,
+  $sshkey_send_key              = $mcollective::client::sshkey_send_key,
+  $sshkey_publickey_dir         = $mcollective::client::sshkey_publickey_dir,
+  $sshkey_learn_public_keys     = $mcollective::client::sshkey_learn_public_keys,
+  $sshkey_overwrite_stored_keys = $mcollective::client::sshkey_overwrite_stored_keys,
 ) {
 
   validate_array( $hosts )

--- a/manifests/userconfig.pp
+++ b/manifests/userconfig.pp
@@ -210,7 +210,7 @@ define mcollective::userconfig(
   
   exec { "create-public-${user}":
     path    => '/usr/bin:/usr/local/bin',
-    command => "openssl rsa -in ${private_key} -out ${public_key}",
+    command => "openssl rsa -in ${private_key} -pubout -out ${public_key}",
     unless  => "/usr/bin/test -e ${public_key}",
     require => Exec["create-private-${user}"],
   }

--- a/manifests/userconfig.pp
+++ b/manifests/userconfig.pp
@@ -184,7 +184,7 @@ define mcollective::userconfig(
   
   $trusted_ssl_server_cert_real = "${homepath}/.puppet/ssl/certs/${user}.pem"
   $trusted_ssl_server_key_real  = "${homepath}/.puppet/ssl/private_keys/${user}.pem"
-  $trusted_ssl_ca_cert_real     = "${homepath}/.puppet/ssl/certs/${user}.pem"
+  $trusted_ssl_ca_cert_real     = "${homepath}/.puppet/ssl/certs/ca.pem"
   
   # Capture the information needed for trusted SSL connections to the local user directory to prevent permission issues
   if( $mcollective::connector_type_ssl == 'trusted') {

--- a/manifests/userconfig.pp
+++ b/manifests/userconfig.pp
@@ -103,6 +103,18 @@
 #    Send the specified public key along with the request for dynamic key management
 #    Default: undefined  (only matters if security_provider is sshkey)
 #
+# [*trusted_ssl_server_cert*]
+#   The path to your trusted server certificate. (Only used with trusted connector_ssl_type)
+#   Default: Re-use your puppet CA infrastructure
+#
+# [*trusted_ssl_server_key*]
+#   The path to your private key used with the trusted server certificate. (Only used with trusted connector_ssl_type)
+#   Default: Re-use your puppet CA infrastructure
+#
+# [*trusted_ssl_ca_cert*]
+#   The path to your trusted certificate authority certificate. (Only used with trusted connector_ssl_type)
+#   Default: Re-use your puppet CA infrastructure
+#
 # === Examples
 #
 #  mcollective::userconfig { 'jorhett':
@@ -122,9 +134,12 @@ define mcollective::userconfig(
   $filename     = '.mcollective',
 
   # This value can be overridden in Hiera or through class parameters
-  $etcdir       = $mcollective::etcdir,
-  $hosts        = $mcollective::hosts,
-  $collectives  = $mcollective::collectives,
+  $etcdir                       = $mcollective::etcdir,
+  $hosts                        = $mcollective::hosts,
+  $collectives                  = $mcollective::collectives,
+  $trusted_ssl_server_cert      = $mcollective::trusted_ssl_server_cert,
+  $trusted_ssl_server_key       = $mcollective::trusted_ssl_server_key,
+  $trusted_ssl_ca_cert          = $mcollective::trusted_ssl_ca_cert,
 
   # Logging
   $logger_type  = $mcollective::client::logger_type,
@@ -229,11 +244,6 @@ define mcollective::userconfig(
     mode    =>  '0500',
     subscribe =>  Exec["create-public-${user}"],
   }
-
-  # Stubs for SSL trusted, must be created by user
-  $ssl_private = "${homepath}/.puppet/ssl/private_keys/${user}.pem"
-  $ssl_cert    = "${homepath}/.puppet/ssl/certs/${user}.pem"
-  $ca_cert     = "${homepath}/.puppet/ssl/certs/ca.pem"
 
   file { "${homepath}/${filename}":
     ensure  => file,

--- a/manifests/userconfig.pp
+++ b/manifests/userconfig.pp
@@ -195,7 +195,7 @@ define mcollective::userconfig(
   }
   
   # If you specified a sshkey public key, use it otherwise create one
-  if( $sshkey_private_key) {
+  if( $sshkey_send_key) {
     $public_key = $sshkey_send_key
   }
   else {

--- a/manifests/userconfig.pp
+++ b/manifests/userconfig.pp
@@ -167,9 +167,9 @@ define mcollective::userconfig(
     $homepath = $homedir
   }
   
-  $trusted_ssl_server_cert_real = "${homepath}/.puppet/ssl/certs/${user}.pem",
-  $trusted_ssl_server_key_real  = "${homepath}/.puppet/ssl/private_keys/${user}.pem",
-  $trusted_ssl_ca_cert_real     = "${homepath}/.puppet/ssl/certs/${user}.pem",
+  $trusted_ssl_server_cert_real = "${homepath}/.puppet/ssl/certs/${user}.pem"
+  $trusted_ssl_server_key_real  = "${homepath}/.puppet/ssl/private_keys/${user}.pem"
+  $trusted_ssl_ca_cert_real     = "${homepath}/.puppet/ssl/certs/${user}.pem"
   
   # Capture the information needed for trusted SSL connections to the local user directory to prevent permission issues
   if( $mcollective::connector_type_ssl == 'trusted') {
@@ -183,7 +183,6 @@ define mcollective::userconfig(
       owner   =>  $user,
       group   =>  $group,
       mode    =>  '0500',
-      # If a specific URL was provided, use it.  Otherwise pull in the system puppet ssl info.
       source  =>  pick($trusted_ssl_server_cert,$mcollective::trusted_ssl_server_cert),
     }
     file {$trusted_ssl_server_key_real:

--- a/manifests/userconfig.pp
+++ b/manifests/userconfig.pp
@@ -36,9 +36,15 @@
 #   How verbose should logging be?
 #   Values: fatal, error, warn (default), info, debug
 #
+# [*sshkey_private_key_content*]
+#    Defines the content of the private key file for hiera-eyaml integration
+#    Default: undefined
+#    When undefined, openssl will be invoked to generate a new private key
+#    This will not inherit from mcollective::client
+#
 # === Variables
 #
-# This class makes use of these variables from base mcollective class
+# This class makes use of these variables from base mcollective class and client mcollective class
 #
 # [*client_user*]
 #   The username clients will use to authenticate.
@@ -69,6 +75,58 @@
 #   Valid to put in the 'caller' field of each request.
 #   Values: uid (default), gid, user, group, identity
 #
+# [*sshkey_publickey_dir*]
+#    Defines a directory to store received sshkey-based keys
+#    Default: undefined  (only matters if security_provider is sshkey)
+#
+# [*sshkey_learn_public_keys*]
+#    Allows the sshkey plugin to write out sent keys to [*sshkey_publickey_dir*]
+#    Default: Do not send  (only matters if security_provider is sshkey)
+#    Values: true,false (default)
+#
+# [*sshkey_overwrite_stored_keys*]
+#    In the event of a key mismatch, overwrite stored key data
+#    Default: Do not overwrite  (only matters if security_provider is sshkey)
+#    Values: true, false (default)
+#
+# [*sshkey_private_key*]
+#    A private key used to sign requests with
+#    Default: undefined  (only matters if security_provider is sshkey)
+#    When undefined, sshkey uses the ssh-agent to find a key
+#
+# [*sshkey_known_hosts*]
+#    A known_hosts file
+#    Default: undefined  (only matters if security_provider is sshkey)
+#    When undefined, sshkey uses /home/$USER/.ssh/known_hosts which is the same as OpenSSH by default
+#
+# [*sshkey_send_key*]
+#    Send the specified public key along with the request for dynamic key management
+#    Default: undefined  (only matters if security_provider is sshkey)
+#
+# [*trusted_ssl_server_cert*]
+#   The path to your trusted server certificate. (Only used with trusted connector_ssl_type)
+#   Default: Re-use your puppet CA infrastructure, captured to your home directory at .puppet/ssl/certs/
+#
+# [*trusted_ssl_server_cert_content*]
+#   The content of your trusted server certificate. (Only used with trusted connector_ssl_type)
+#   Default: Re-use your puppet CA infrastructure, captured to your home directory at .puppet/ssl/certs/
+#
+# [*trusted_ssl_server_key*]
+#   The path to your private key used with the trusted server certificate. (Only used with trusted connector_ssl_type)
+#   Default: Re-use your puppet CA infrastructure, captured to your home directory at .puppet/ssl/private_keys/
+#
+# [*trusted_ssl_server_key_content*]
+#   The content of your private key used with the trusted server certificate. (Only used with trusted connector_ssl_type)
+#   Default: Re-use your puppet CA infrastructure, captured to your home directory at .puppet/ssl/private_keys/
+#
+# [*trusted_ssl_ca_cert*]
+#   The path to your trusted certificate authority certificate. (Only used with trusted connector_ssl_type)
+#   Default: Re-use your puppet CA infrastructure, captured to your home directory at .puppet/ssl/certs/
+#
+# [*trusted_ssl_ca_cert_content*]
+#   The content of your trusted certificate authority certificate. (Only used with trusted connector_ssl_type)
+#   Default: Re-use your puppet CA infrastructure, captured to your home directory at .puppet/ssl/certs/
+#
 # === Examples
 #
 #  mcollective::userconfig { 'jorhett':
@@ -88,13 +146,28 @@ define mcollective::userconfig(
   $filename     = '.mcollective',
 
   # This value can be overridden in Hiera or through class parameters
-  $etcdir       = $mcollective::etcdir,
-  $hosts        = $mcollective::hosts,
-  $collectives  = $mcollective::collectives,
+  $etcdir                           = $mcollective::etcdir,
+  $hosts                            = $mcollective::hosts,
+  $collectives                      = $mcollective::collectives,
+  $trusted_ssl_server_cert          = undef,
+  $trusted_ssl_server_cert_content  = undef,
+  $trusted_ssl_server_key           = undef,
+  $trusted_ssl_server_key_content   = undef,
+  $trusted_ssl_ca_cert              = undef,
+  $trusted_ssl_ca_cert_content      = undef,
 
   # Logging
   $logger_type  = $mcollective::client::logger_type,
   $log_level    = $mcollective::client::log_level,
+  
+  # Authentication
+  $sshkey_private_key           = $mcollective::client::sshkey_private_key,
+  $sshkey_private_key_content   = undef,
+  $sshkey_known_hosts           = $mcollective::client::sshkey_known_hosts,
+  $sshkey_send_key              = $mcollective::client::sshkey_send_key,
+  $sshkey_publickey_dir         = $mcollective::client::sshkey_publickey_dir,
+  $sshkey_learn_public_keys     = $mcollective::client::sshkey_learn_public_keys,
+  $sshkey_overwrite_stored_keys = $mcollective::client::sshkey_overwrite_stored_keys,
 ) {
 
   validate_array( $hosts )
@@ -108,36 +181,117 @@ define mcollective::userconfig(
   else {
     $homepath = $homedir
   }
-  $private_key = "${homepath}/.mcollective.d/private_keys/${user}.pem"
-  $public_key  = "${homepath}/.mcollective.d/public_keys/${user}.pem"
-
-  # Stubs for SSL trusted, must be created by user
-  $ssl_private = "${homepath}/.puppet/ssl/private_keys/${user}.pem"
-  $ssl_cert    = "${homepath}/.puppet/ssl/certs/${user}.pem"
-  $ca_cert     = "${homepath}/.puppet/ssl/certs/ca.pem"
-
-  file {[
-          "${homepath}/.mcollective.d",
-          "${homepath}/.mcollective.d/private_keys",
-          "${homepath}/.mcollective.d/public_keys",
-          "${homepath}/.mcollective.d/certs",
-        ]:
-    ensure => 'directory',
-    owner  => $user,
-    group  => $group,
+  
+  $trusted_ssl_server_cert_real = "${homepath}/.puppet/ssl/certs/${user}.pem"
+  $trusted_ssl_server_key_real  = "${homepath}/.puppet/ssl/private_keys/${user}.pem"
+  $trusted_ssl_ca_cert_real     = "${homepath}/.puppet/ssl/certs/ca.pem"
+  
+  # Capture the information needed for trusted SSL connections to the local user directory to prevent permission issues
+  if( $mcollective::connector_type_ssl == 'trusted') {
+    file {["${homepath}/.puppet","${homepath}/.puppet/ssl","${homepath}/.puppet/ssl/certs","${homepath}/.puppet/ssl/private_keys"]:
+      ensure => 'directory',
+      owner  => $user,
+      group  => $group,
+    }
+    file {$trusted_ssl_server_cert_real:
+      ensure  =>  file,
+      owner   =>  $user,
+      group   =>  $group,
+      mode    =>  '0500',
+      content  =>  pick($trusted_ssl_server_cert_content,file($trusted_ssl_server_cert),file($mcollective::trusted_ssl_server_cert)),
+    }
+    file {$trusted_ssl_server_key_real:
+      ensure  =>  file,
+      owner   =>  $user,
+      group   =>  $group,
+      mode    =>  '0500',
+      content  =>  pick($trusted_ssl_server_key_content,file($trusted_ssl_server_key),file($mcollective::trusted_ssl_server_key)),
+    }
+    file {$trusted_ssl_ca_cert_real:
+      ensure  =>  file,
+      owner   =>  $user,
+      group   =>  $group,
+      mode    =>  '0500',
+      content  =>  pick($trusted_ssl_ca_cert_content,file($trusted_ssl_ca_cert),file($mcollective::trusted_ssl_ca_cert)),
+    }
   }
-
-  exec { "create-private-${user}":
-    path    => '/usr/bin:/usr/local/bin',
-    command => "openssl genrsa -out ${private_key} 2048",
-    unless  => "/usr/bin/test -e ${private_key}",
+  
+  # Create the parent default directory if needed
+  if( !$sshkey_private_key or !$sshkey_send_key){
+    file {"${homepath}/.mcollective.d":
+      ensure => 'directory',
+      owner  => $user,
+      group  => $group,
+    }
   }
-
+  
+  # If you specified a sshkey private key, use it otherwise create one
+  if( $sshkey_private_key) {
+    $private_key = $sshkey_private_key
+  }
+  else {
+    file {"${homepath}/.mcollective.d/private_keys":
+      ensure => 'directory',
+      owner  => $user,
+      group  => $group,
+    }
+    
+    $private_key = "${homepath}/.mcollective.d/private_keys/${user}.pem"
+  }
+  
+  # If the key content was provided, use it
+  if( $sshkey_private_key_content ){
+    file {$private_key:
+      ensure  =>  file,
+      owner   =>  $user,
+      group   =>  $group,
+      mode    =>  '0500',
+      content =>  $sshkey_private_key_content,
+    }
+  }
+  else {
+    # Generate a new private key
+    exec { "create-private-${user}":
+      path    => '/usr/bin:/usr/local/bin',
+      command => "openssl genrsa -out ${private_key} 2048",
+      unless  => "/usr/bin/test -e ${private_key}",
+    }
+    
+    file {$private_key:
+      ensure  =>  file,
+      owner   =>  $user,
+      group   =>  $group,
+      mode    =>  '0500',
+      subscribe =>  Exec["create-private-${user}"],
+    }
+  }
+  
+  # If you specified a sshkey public key, use it otherwise create one
+  if( $sshkey_send_key) {
+    $public_key = $sshkey_send_key
+  }
+  else {
+    file {"${homepath}/.mcollective.d/public_keys":
+      ensure => 'directory',
+      owner  => $user,
+      group  => $group,
+    }
+    
+    $public_key  = "${homepath}/.mcollective.d/public_keys/${user}.pem"
+  }
+  
   exec { "create-public-${user}":
     path    => '/usr/bin:/usr/local/bin',
-    command => "openssl rsa -in ${private_key} -out ${public_key}",
+    command => "ssh-keygen -y -f ${private_key} > ${public_key}",
     unless  => "/usr/bin/test -e ${public_key}",
     require => Exec["create-private-${user}"],
+  }
+  file {$public_key:
+    ensure  =>  file,
+    owner   =>  $user,
+    group   =>  $group,
+    mode    =>  '0500',
+    subscribe =>  Exec["create-public-${user}"],
   }
 
   file { "${homepath}/${filename}":

--- a/manifests/userconfig.pp
+++ b/manifests/userconfig.pp
@@ -222,6 +222,13 @@ define mcollective::userconfig(
     unless  => "/usr/bin/test -e ${public_key}",
     require => Exec["create-private-${user}"],
   }
+  file {$public_key:
+    ensure  =>  file,
+    owner   =>  $user,
+    group   =>  $group,
+    mode    =>  '0500',
+    subscribe =>  Exec["create-public-${user}"],
+  }
 
   # Stubs for SSL trusted, must be created by user
   $ssl_private = "${homepath}/.puppet/ssl/private_keys/${user}.pem"

--- a/manifests/userconfig.pp
+++ b/manifests/userconfig.pp
@@ -192,6 +192,14 @@ define mcollective::userconfig(
       command => "openssl genrsa -out ${private_key} 2048",
       unless  => "/usr/bin/test -e ${private_key}",
     }
+    
+    file {$private_key:
+      ensure  =>  file,
+      owner   =>  $user,
+      group   =>  $group,
+      mode    =>  '0500',
+      subscribe =>  Exec["create-private-${user}"],
+    }
   }
   
   # If you specified a sshkey public key, use it otherwise create one

--- a/templates/client.cfg.erb
+++ b/templates/client.cfg.erb
@@ -23,8 +23,12 @@ plugin.<%= scope.lookupvar('mcollective::connector') -%>.pool.<%= index+1 -%>.us
 plugin.<%= scope.lookupvar('mcollective::connector') -%>.pool.<%= index+1 -%>.password = <%= scope.lookupvar('mcollective::client_password') %>
 <% if( scope.lookupvar('mcollective::connector') == 'activemq' ) then -%>
 plugin.<%= scope.lookupvar('mcollective::connector') -%>.pool.<%= index+1 -%>.ssl = <%= scope.lookupvar('mcollective::connector_ssl')  %>
-<% if( scope.lookupvar('mcollective::connector_ssl_type') != 'trusted' ) then -%>
-plugin.<%= scope.lookupvar('mcollective::connector') -%>.pool.<%= index+1 -%>.ssl.fallback = true                          
+<% if( scope.lookupvar('mcollective::connector_ssl_type') == 'trusted' ) then -%>
+plugin.<%= scope.lookupvar('mcollective::connector') -%>.pool.<%= index+1 -%>.ssl.key = <%= scope.lookupvar('::ssldir') -%>/private_keys/<%= scope.lookupvar('clientcert') -%>.pem
+plugin.<%= scope.lookupvar('mcollective::connector') -%>.pool.<%= index+1 -%>.ssl.cert = <%= scope.lookupvar('::ssldir') -%>/certs/<%= scope.lookupvar('clientcert') -%>.pem
+plugin.<%= scope.lookupvar('mcollective::connector') -%>.pool.<%= index+1 -%>.ssl.ca = <%= scope.lookupvar('::ssldir') -%>/certs/ca.pem
+<% else -%>
+plugin.<%= scope.lookupvar('mcollective::connector') -%>.pool.<%= index+1 -%>.ssl.fallback = true
 <% end -%>
 <% end -%>
 <% end -%>

--- a/templates/client.cfg.erb
+++ b/templates/client.cfg.erb
@@ -23,8 +23,12 @@ plugin.<%= scope.lookupvar('mcollective::connector') -%>.pool.<%= index+1 -%>.us
 plugin.<%= scope.lookupvar('mcollective::connector') -%>.pool.<%= index+1 -%>.password = <%= scope.lookupvar('mcollective::client_password') %>
 <% if( scope.lookupvar('mcollective::connector') == 'activemq' ) then -%>
 plugin.<%= scope.lookupvar('mcollective::connector') -%>.pool.<%= index+1 -%>.ssl = <%= scope.lookupvar('mcollective::connector_ssl')  %>
-<% if( scope.lookupvar('mcollective::connector_ssl_type') != 'trusted' ) then -%>
-plugin.<%= scope.lookupvar('mcollective::connector') -%>.pool.<%= index+1 -%>.ssl.fallback = true                          
+<% if( scope.lookupvar('mcollective::connector_ssl_type') == 'trusted' ) then -%>
+plugin.<%= scope.lookupvar('mcollective::connector') -%>.pool.<%= index+1 -%>.ssl.key = <%= @trusted_ssl_server_key %>
+plugin.<%= scope.lookupvar('mcollective::connector') -%>.pool.<%= index+1 -%>.ssl.cert = <%= @trusted_ssl_server_cert %>
+plugin.<%= scope.lookupvar('mcollective::connector') -%>.pool.<%= index+1 -%>.ssl.ca = <%= @trusted_ssl_ca_cert %>
+<% else -%>
+plugin.<%= scope.lookupvar('mcollective::connector') -%>.pool.<%= index+1 -%>.ssl.fallback = true
 <% end -%>
 <% end -%>
 <% end -%>
@@ -36,9 +40,20 @@ plugin.psk = <%= scope.lookupvar('mcollective::psk_key') %>
 plugin.psk.callertype = <%= scope.lookupvar('mcollective::psk_callertype') %>
 <% elsif( scope.lookupvar('mcollective::security_provider') == 'sshkey' ) then -%>
 securityprovider = sshkey
+plugin.sshkey.client.learn_public_keys = <%= @sshkey_learn_public_keys %>
+plugin.sshkey.client.overwrite_stored_keys = <%= @sshkey_overwrite_stored_keys %>
 <% if( @sshkey_known_hosts ) then -%>
 plugin.sshkey.client.known_hosts = <%= @sshkey_known_hosts %>
 <% end -%>
+<% if( @sshkey_private_key ) then -%>
+plugin.sshkey.client.private_key = <%= @sshkey_private_key %>
+<% end -%> 
+<% if( @sshkey_send_key ) then -%>
+plugin.sshkey.client.send_key = <%= @sshkey_send_key %>
+<% end -%> 
+<% if( @sshkey_publickey_dir ) then -%>
+plugin.sshkey.client.publickey_dir = <%= @sshkey_publickey_dir %>
+<% end -%> 
 <% elsif( scope.lookupvar('mcollective::security_provider') == 'ssl' ) then -%>
 securityprovider = ssl
 plugin.ssl_server_public = <%= scope.lookupvar('mcollective::etcdir') -%>/ssl/server/public.pem

--- a/templates/client.cfg.erb
+++ b/templates/client.cfg.erb
@@ -40,9 +40,20 @@ plugin.psk = <%= scope.lookupvar('mcollective::psk_key') %>
 plugin.psk.callertype = <%= scope.lookupvar('mcollective::psk_callertype') %>
 <% elsif( scope.lookupvar('mcollective::security_provider') == 'sshkey' ) then -%>
 securityprovider = sshkey
+plugin.sshkey.client.learn_public_keys = <%= @sshkey_learn_public_keys %>
+plugin.sshkey.client.overwrite_stored_keys = <%= @sshkey_overwrite_stored_keys %>
 <% if( @sshkey_known_hosts ) then -%>
 plugin.sshkey.client.known_hosts = <%= @sshkey_known_hosts %>
 <% end -%>
+<% if( @sshkey_private_key ) then -%>
+plugin.sshkey.client.private_key = <%= @sshkey_private_key %>
+<% end -%> 
+<% if( @sshkey_send_key ) then -%>
+plugin.sshkey.client.send_key = <%= @sshkey_send_key %>
+<% end -%> 
+<% if( @sshkey_publickey_dir ) then -%>
+plugin.sshkey.client.publickey_dir = <%= @sshkey_publickey_dir %>
+<% end -%> 
 <% elsif( scope.lookupvar('mcollective::security_provider') == 'ssl' ) then -%>
 securityprovider = ssl
 plugin.ssl_server_public = <%= scope.lookupvar('mcollective::etcdir') -%>/ssl/server/public.pem

--- a/templates/client.cfg.erb
+++ b/templates/client.cfg.erb
@@ -24,9 +24,9 @@ plugin.<%= scope.lookupvar('mcollective::connector') -%>.pool.<%= index+1 -%>.pa
 <% if( scope.lookupvar('mcollective::connector') == 'activemq' ) then -%>
 plugin.<%= scope.lookupvar('mcollective::connector') -%>.pool.<%= index+1 -%>.ssl = <%= scope.lookupvar('mcollective::connector_ssl')  %>
 <% if( scope.lookupvar('mcollective::connector_ssl_type') == 'trusted' ) then -%>
-plugin.<%= scope.lookupvar('mcollective::connector') -%>.pool.<%= index+1 -%>.ssl.key = <%= scope.lookupvar('::ssldir') -%>/private_keys/<%= scope.lookupvar('clientcert') -%>.pem
-plugin.<%= scope.lookupvar('mcollective::connector') -%>.pool.<%= index+1 -%>.ssl.cert = <%= scope.lookupvar('::ssldir') -%>/certs/<%= scope.lookupvar('clientcert') -%>.pem
-plugin.<%= scope.lookupvar('mcollective::connector') -%>.pool.<%= index+1 -%>.ssl.ca = <%= scope.lookupvar('::ssldir') -%>/certs/ca.pem
+plugin.<%= scope.lookupvar('mcollective::connector') -%>.pool.<%= index+1 -%>.ssl.key = <%= @trusted_ssl_server_key %>
+plugin.<%= scope.lookupvar('mcollective::connector') -%>.pool.<%= index+1 -%>.ssl.cert = <%= @trusted_ssl_server_cert %>
+plugin.<%= scope.lookupvar('mcollective::connector') -%>.pool.<%= index+1 -%>.ssl.ca = <%= @trusted_ssl_ca_cert %>
 <% else -%>
 plugin.<%= scope.lookupvar('mcollective::connector') -%>.pool.<%= index+1 -%>.ssl.fallback = true
 <% end -%>

--- a/templates/server.cfg.erb
+++ b/templates/server.cfg.erb
@@ -46,8 +46,19 @@ securityprovider = psk
 plugin.psk = <%= scope.lookupvar('mcollective::psk_key') %>
 <% elsif( scope.lookupvar('mcollective::security_provider') == 'sshkey' ) then -%>                                                                                                                                           
 securityprovider = sshkey
+plugin.sshkey.server.learn_public_keys = <%= @sshkey_learn_public_keys %>
+plugin.sshkey.server.overwrite_stored_keys = <%= @sshkey_overwrite_stored_keys %>
 <% if( @sshkey_authorized_keys ) then -%>
 plugin.sshkey.server.known_hosts = <%= @sshkey_authorized_keys %>
+<% end -%> 
+<% if( @sshkey_private_key ) then -%>
+plugin.sshkey.server.private_key = <%= @sshkey_private_key %>
+<% end -%> 
+<% if( @sshkey_send_key ) then -%>
+plugin.sshkey.server.send_key = <%= @sshkey_send_key %>
+<% end -%> 
+<% if( @sshkey_publickey_dir ) then -%>
+plugin.sshkey.server.publickey_dir = <%= @sshkey_publickey_dir %>
 <% end -%> 
 <% elsif( scope.lookupvar('mcollective::security_provider') == 'ssl' ) then -%>
 securityprovider = ssl

--- a/templates/server.cfg.erb
+++ b/templates/server.cfg.erb
@@ -27,9 +27,9 @@ plugin.<%= scope.lookupvar('mcollective::connector') -%>.pool.<%= index+1 -%>.pa
 <% if( scope.lookupvar('mcollective::connector') == 'activemq' ) then -%>
 plugin.<%= scope.lookupvar('mcollective::connector') -%>.pool.<%= index+1 -%>.ssl = <%= scope.lookupvar('mcollective::connector_ssl')  %>
 <% if( scope.lookupvar('mcollective::connector_ssl_type') == 'trusted' ) then -%>
-plugin.<%= scope.lookupvar('mcollective::connector') -%>.pool.<%= index+1 -%>.ssl.key = <%= scope.lookupvar('::ssldir') -%>/private_keys/<%= scope.lookupvar('clientcert') -%>.pem
-plugin.<%= scope.lookupvar('mcollective::connector') -%>.pool.<%= index+1 -%>.ssl.cert = <%= scope.lookupvar('::ssldir') -%>/certs/<%= scope.lookupvar('clientcert') -%>.pem
-plugin.<%= scope.lookupvar('mcollective::connector') -%>.pool.<%= index+1 -%>.ssl.ca = <%= scope.lookupvar('::ssldir') -%>/certs/ca.pem
+plugin.<%= scope.lookupvar('mcollective::connector') -%>.pool.<%= index+1 -%>.ssl.key = <%= @trusted_ssl_server_key %>
+plugin.<%= scope.lookupvar('mcollective::connector') -%>.pool.<%= index+1 -%>.ssl.cert = <%= @trusted_ssl_server_cert %>
+plugin.<%= scope.lookupvar('mcollective::connector') -%>.pool.<%= index+1 -%>.ssl.ca = <%= @trusted_ssl_ca_cert %>
 <% else -%>
 plugin.<%= scope.lookupvar('mcollective::connector') -%>.pool.<%= index+1 -%>.ssl.fallback = true
 <% end -%>
@@ -46,8 +46,19 @@ securityprovider = psk
 plugin.psk = <%= scope.lookupvar('mcollective::psk_key') %>
 <% elsif( scope.lookupvar('mcollective::security_provider') == 'sshkey' ) then -%>                                                                                                                                           
 securityprovider = sshkey
+plugin.sshkey.server.learn_public_keys = <%= @sshkey_learn_public_keys %>
+plugin.sshkey.server.overwrite_stored_keys = <%= @sshkey_overwrite_stored_keys %>
 <% if( @sshkey_authorized_keys ) then -%>
 plugin.sshkey.server.known_hosts = <%= @sshkey_authorized_keys %>
+<% end -%> 
+<% if( @sshkey_private_key ) then -%>
+plugin.sshkey.server.private_key = <%= @sshkey_private_key %>
+<% end -%> 
+<% if( @sshkey_send_key ) then -%>
+plugin.sshkey.server.send_key = <%= @sshkey_send_key %>
+<% end -%> 
+<% if( @sshkey_publickey_dir ) then -%>
+plugin.sshkey.server.publickey_dir = <%= @sshkey_publickey_dir %>
 <% end -%> 
 <% elsif( scope.lookupvar('mcollective::security_provider') == 'ssl' ) then -%>
 securityprovider = ssl

--- a/templates/server.cfg.erb
+++ b/templates/server.cfg.erb
@@ -27,9 +27,9 @@ plugin.<%= scope.lookupvar('mcollective::connector') -%>.pool.<%= index+1 -%>.pa
 <% if( scope.lookupvar('mcollective::connector') == 'activemq' ) then -%>
 plugin.<%= scope.lookupvar('mcollective::connector') -%>.pool.<%= index+1 -%>.ssl = <%= scope.lookupvar('mcollective::connector_ssl')  %>
 <% if( scope.lookupvar('mcollective::connector_ssl_type') == 'trusted' ) then -%>
-plugin.<%= scope.lookupvar('mcollective::connector') -%>.pool.<%= index+1 -%>.ssl.key = <%= scope.lookupvar('::ssldir') -%>/private_keys/<%= scope.lookupvar('clientcert') -%>.pem
-plugin.<%= scope.lookupvar('mcollective::connector') -%>.pool.<%= index+1 -%>.ssl.cert = <%= scope.lookupvar('::ssldir') -%>/certs/<%= scope.lookupvar('clientcert') -%>.pem
-plugin.<%= scope.lookupvar('mcollective::connector') -%>.pool.<%= index+1 -%>.ssl.ca = <%= scope.lookupvar('::ssldir') -%>/certs/ca.pem
+plugin.<%= scope.lookupvar('mcollective::connector') -%>.pool.<%= index+1 -%>.ssl.key = <%= @trusted_ssl_server_key %>
+plugin.<%= scope.lookupvar('mcollective::connector') -%>.pool.<%= index+1 -%>.ssl.cert = <%= @trusted_ssl_server_cert %>
+plugin.<%= scope.lookupvar('mcollective::connector') -%>.pool.<%= index+1 -%>.ssl.ca = <%= @trusted_ssl_ca_cert %>
 <% else -%>
 plugin.<%= scope.lookupvar('mcollective::connector') -%>.pool.<%= index+1 -%>.ssl.fallback = true
 <% end -%>

--- a/templates/userconfig.erb
+++ b/templates/userconfig.erb
@@ -21,9 +21,9 @@ plugin.<%= scope.lookupvar('mcollective::connector') -%>.pool.<%= index+1 -%>.pa
 <% if( scope.lookupvar('mcollective::connector') == 'activemq' ) then -%>
 plugin.<%= scope.lookupvar('mcollective::connector') -%>.pool.<%= index+1 -%>.ssl = <%= scope.lookupvar('mcollective::connector_ssl')  %>
 <% if( scope.lookupvar('mcollective::connector_ssl_type') == 'trusted' ) then -%>
-plugin.<%= scope.lookupvar('mcollective::connector') -%>.pool.<%= index+1 -%>.ssl.key = <%= scope.lookupvar('ssl_private') %>
-plugin.<%= scope.lookupvar('mcollective::connector') -%>.pool.<%= index+1 -%>.ssl.cert = <%= scope.lookupvar('ssl_cert') %>
-plugin.<%= scope.lookupvar('mcollective::connector') -%>.pool.<%= index+1 -%>.ssl.ca = <%= scope.lookupvar('ca_cert') %>
+plugin.<%= scope.lookupvar('mcollective::connector') -%>.pool.<%= index+1 -%>.ssl.key = <%= @trusted_ssl_server_key_real %>
+plugin.<%= scope.lookupvar('mcollective::connector') -%>.pool.<%= index+1 -%>.ssl.cert = <%= @trusted_ssl_server_cert_real %>
+plugin.<%= scope.lookupvar('mcollective::connector') -%>.pool.<%= index+1 -%>.ssl.ca = <%= @trusted_ssl_ca_cert_real %>
 <% else -%>
 plugin.<%= scope.lookupvar('mcollective::connector') -%>.pool.<%= index+1 -%>.ssl.fallback = true                          
 <% end -%>
@@ -37,9 +37,20 @@ plugin.psk = <%= scope.lookupvar('mcollective::psk_key') %>
 plugin.psk.callertype = <%= scope.lookupvar('mcollective::psk_callertype') %>
 <% elsif( scope.lookupvar('mcollective::security_provider') == 'sshkey' ) then -%>
 securityprovider = sshkey
+plugin.sshkey.client.learn_public_keys = <%= @sshkey_learn_public_keys %>
+plugin.sshkey.client.overwrite_stored_keys = <%= @sshkey_overwrite_stored_keys %>
 <% if( @sshkey_known_hosts ) then -%>
 plugin.sshkey.client.known_hosts = <%= @sshkey_known_hosts %>
 <% end -%>
+<% if( @sshkey_private_key ) then -%>
+plugin.sshkey.client.private_key = <%= @sshkey_private_key %>
+<% end -%> 
+<% if( @sshkey_send_key ) then -%>
+plugin.sshkey.client.send_key = <%= @sshkey_send_key %>
+<% end -%> 
+<% if( @sshkey_publickey_dir ) then -%>
+plugin.sshkey.client.publickey_dir = <%= @sshkey_publickey_dir %>
+<% end -%> 
 <% elsif( scope.lookupvar('mcollective::security_provider') == 'ssl' ) then -%>
 securityprovider = ssl
 plugin.ssl_server_public = <%= scope.lookupvar('mcollective::etcdir') -%>/ssl/server/public.pem

--- a/templates/userconfig.erb
+++ b/templates/userconfig.erb
@@ -21,9 +21,9 @@ plugin.<%= scope.lookupvar('mcollective::connector') -%>.pool.<%= index+1 -%>.pa
 <% if( scope.lookupvar('mcollective::connector') == 'activemq' ) then -%>
 plugin.<%= scope.lookupvar('mcollective::connector') -%>.pool.<%= index+1 -%>.ssl = <%= scope.lookupvar('mcollective::connector_ssl')  %>
 <% if( scope.lookupvar('mcollective::connector_ssl_type') == 'trusted' ) then -%>
-plugin.<%= scope.lookupvar('mcollective::connector') -%>.pool.<%= index+1 -%>.ssl.key = <%= @trusted_ssl_server_key %>
-plugin.<%= scope.lookupvar('mcollective::connector') -%>.pool.<%= index+1 -%>.ssl.cert = <%= @trusted_ssl_server_cert %>
-plugin.<%= scope.lookupvar('mcollective::connector') -%>.pool.<%= index+1 -%>.ssl.ca = <%= @trusted_ssl_ca_cert %>
+plugin.<%= scope.lookupvar('mcollective::connector') -%>.pool.<%= index+1 -%>.ssl.key = <%= @trusted_ssl_server_key_real %>
+plugin.<%= scope.lookupvar('mcollective::connector') -%>.pool.<%= index+1 -%>.ssl.cert = <%= @trusted_ssl_server_cert_real %>
+plugin.<%= scope.lookupvar('mcollective::connector') -%>.pool.<%= index+1 -%>.ssl.ca = <%= @trusted_ssl_ca_cert_real %>
 <% else -%>
 plugin.<%= scope.lookupvar('mcollective::connector') -%>.pool.<%= index+1 -%>.ssl.fallback = true                          
 <% end -%>

--- a/templates/userconfig.erb
+++ b/templates/userconfig.erb
@@ -37,9 +37,20 @@ plugin.psk = <%= scope.lookupvar('mcollective::psk_key') %>
 plugin.psk.callertype = <%= scope.lookupvar('mcollective::psk_callertype') %>
 <% elsif( scope.lookupvar('mcollective::security_provider') == 'sshkey' ) then -%>
 securityprovider = sshkey
+plugin.sshkey.client.learn_public_keys = <%= @sshkey_learn_public_keys %>
+plugin.sshkey.client.overwrite_stored_keys = <%= @sshkey_overwrite_stored_keys %>
 <% if( @sshkey_known_hosts ) then -%>
 plugin.sshkey.client.known_hosts = <%= @sshkey_known_hosts %>
 <% end -%>
+<% if( @sshkey_private_key ) then -%>
+plugin.sshkey.client.private_key = <%= @sshkey_private_key %>
+<% end -%> 
+<% if( @sshkey_send_key ) then -%>
+plugin.sshkey.client.send_key = <%= @sshkey_send_key %>
+<% end -%> 
+<% if( @sshkey_publickey_dir ) then -%>
+plugin.sshkey.client.publickey_dir = <%= @sshkey_publickey_dir %>
+<% end -%> 
 <% elsif( scope.lookupvar('mcollective::security_provider') == 'ssl' ) then -%>
 securityprovider = ssl
 plugin.ssl_server_public = <%= scope.lookupvar('mcollective::etcdir') -%>/ssl/server/public.pem

--- a/templates/userconfig.erb
+++ b/templates/userconfig.erb
@@ -21,9 +21,9 @@ plugin.<%= scope.lookupvar('mcollective::connector') -%>.pool.<%= index+1 -%>.pa
 <% if( scope.lookupvar('mcollective::connector') == 'activemq' ) then -%>
 plugin.<%= scope.lookupvar('mcollective::connector') -%>.pool.<%= index+1 -%>.ssl = <%= scope.lookupvar('mcollective::connector_ssl')  %>
 <% if( scope.lookupvar('mcollective::connector_ssl_type') == 'trusted' ) then -%>
-plugin.<%= scope.lookupvar('mcollective::connector') -%>.pool.<%= index+1 -%>.ssl.key = <%= scope.lookupvar('ssl_private') %>
-plugin.<%= scope.lookupvar('mcollective::connector') -%>.pool.<%= index+1 -%>.ssl.cert = <%= scope.lookupvar('ssl_cert') %>
-plugin.<%= scope.lookupvar('mcollective::connector') -%>.pool.<%= index+1 -%>.ssl.ca = <%= scope.lookupvar('ca_cert') %>
+plugin.<%= scope.lookupvar('mcollective::connector') -%>.pool.<%= index+1 -%>.ssl.key = <%= @trusted_ssl_server_key %>
+plugin.<%= scope.lookupvar('mcollective::connector') -%>.pool.<%= index+1 -%>.ssl.cert = <%= @trusted_ssl_server_cert %>
+plugin.<%= scope.lookupvar('mcollective::connector') -%>.pool.<%= index+1 -%>.ssl.ca = <%= @trusted_ssl_ca_cert %>
 <% else -%>
 plugin.<%= scope.lookupvar('mcollective::connector') -%>.pool.<%= index+1 -%>.ssl.fallback = true                          
 <% end -%>


### PR DESCRIPTION
This is a fairly sizable PR for a few things.
- Bugfixes:
  - Fixes a typo which would have never set the authorized key file - c6b02b684a8406b8174e46891ccec8c669f0576a
  - sshkeyauth requires an openssh formatted public key, not a private key or an openssl formatted public key - 2d9ed22a85b82d7014adfd4dcd8b6e8f8daa7851
  - Includes PR10 bugfix for missing trusted ssl parameters on clients
- Enhancements:
  - Added sshkey plugin and deployment code
  - Added new parameters to support additional functionality in sshkeyauth
  - Refactored how the trusted ssl connector type parameters are handled for consistency and ability to override
- Changes:
  - User trusted SSL configuration will always be captured to $home/.puppet for permissions reasons and enforced.
