### PR TITLE
add classesfile path for puppet 3 hosts

### DIFF
--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -318,13 +318,6 @@ class mcollective::server(
 
   # Only install logrotate if the logrotate directory is installed
   if( $logrotate_directory ) {
-    file { 'logrotate-directory':
-      ensure => directory,
-      path   => $logrotate_directory,
-      owner  => 0,
-      group  => 0,
-      mode   => '0755',
-    }
     file { 'logrotate-auditlog':
       ensure  => $auditlog_ensure,
       path    => "${logrotate_directory}/mcollective-auditlog",

--- a/templates/server.cfg.erb
+++ b/templates/server.cfg.erb
@@ -3,6 +3,8 @@ libdir = <%= scope.lookupvar('mcollective::libdir') %>
 <% if( scope.lookupvar('::clientversion').to_f >= 4.0 ) then -%>
 libdir = /opt/puppetlabs/mcollective/plugins
 classesfile = /opt/puppetlabs/puppet/cache/state/classes.txt
+<% else %>
+classesfile = /var/lib/puppet/classes.txt
 <% end -%>
 daemonize = 1
 direct_addressing = 1


### PR DESCRIPTION
master branch sets classes file for puppet 4 hosts but not for puppet 3. might as well set it by default.
