### PR TITLE
Support plugin.activemq.base64 = yes/no

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 /pkg/
+Gemfile.lock
+spec/fixtures

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -98,6 +98,7 @@ class mcollective(
   $security_provider    = 'psk',
   $psk_key              = undef,   # will be checked if provider = psk
   $psk_callertype       = 'uid',
+  $activemq_base64      = undef, # Can be set to true to set 'plugin.activemq.base64 = yes' in server.cfg/client.cfg configuration files.
 )
   inherits mcollective::params {
 
@@ -112,6 +113,9 @@ class mcollective(
   validate_re( $connector, [ '^activemq$', '^rabbitmq$' ] )
   validate_re( $security_provider, [ '^psk$', '^sshkey$', '^ssl', '^aes_security' ] )
   validate_bool( $connector_ssl )
+  if ( $activemq_base64 != undef ) {
+    validate_bool( $activemq_base64 )
+  }
 
   if( $security_provider == 'psk' ) {
     validate_re( $psk_key, '^\S{20}', 'Please use a longer string of non-whitespace characters for the pre-shared key' )

--- a/spec/classes/client_spec.rb
+++ b/spec/classes/client_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe 'mcollective::client' do
   let(:pre_condition) do
     'class { "mcollective":
-      hosts           => ["middleware.example.net"],                                                                                                                                                         
+      hosts           => ["middleware.example.net"],
       client_password => "fakeTestingClientPassword",
       server_password => "fakeTestingServerPassword",
       psk_key         => "fakeTestingPreSharedKey",
@@ -85,6 +85,45 @@ describe 'mcollective::client' do
 
     it do
       should contain_package('rubygem-stomp').with({ 'name' => 'rubygem-stomp' })
+    end
+  end
+
+  describe 'templated client.cfg' do
+    context 'With default activemq_base64 parameter (undef)' do
+      it 'should NOT contain plugin.activemq.base64 configuration' do
+        content = catalogue.resource('file', '/etc/puppetlabs/mcollective/client.cfg').send(:parameters)[:content]
+        expect(content).not_to include('plugin.activemq.base64')
+      end
+    end
+    context 'With activemq_base64 parameter set to true' do
+      let(:pre_condition) {
+        'class { "mcollective":
+          hosts           => ["middleware.example.net"],
+          client_password => "fakeTestingClientPassword",
+          server_password => "fakeTestingServerPassword",
+          psk_key         => "fakeTestingPreSharedKey",
+          activemq_base64 => true,
+        }'
+      }
+      it 'should contain plugin.activemq.base64 = yes' do
+        content = catalogue.resource('file', '/etc/puppetlabs/mcollective/client.cfg').send(:parameters)[:content]
+        expect(content).to match(/^plugin\.activemq\.base64 = yes$/)
+      end
+    end
+    context 'With activemq_base64 parameter set to false' do
+      let(:pre_condition) {
+        'class { "mcollective":
+          hosts           => ["middleware.example.net"],
+          client_password => "fakeTestingClientPassword",
+          server_password => "fakeTestingServerPassword",
+          psk_key         => "fakeTestingPreSharedKey",
+          activemq_base64 => false,
+        }'
+      }
+      it 'should contain plugin.activemq.base64 = no' do
+        content = catalogue.resource('file', '/etc/puppetlabs/mcollective/client.cfg').send(:parameters)[:content]
+        expect(content).to match(/^plugin\.activemq\.base64 = no$/)
+      end
     end
   end
 end

--- a/spec/classes/server_spec.rb
+++ b/spec/classes/server_spec.rb
@@ -1,9 +1,9 @@
 require 'spec_helper'
 
 describe 'mcollective::server' do
-  let(:pre_condition) { 
+  let(:pre_condition) {
     'class { "mcollective":
-      hosts           => ["middleware.example.net"],                                                                                                                                                         
+      hosts           => ["middleware.example.net"],
       client_password => "fakeTestingClientPassword",
       server_password => "fakeTestingServerPassword",
       psk_key         => "fakeTestingPreSharedKey",
@@ -114,6 +114,44 @@ describe 'mcollective::server' do
 
     it do
       should contain_package('rubygem-stomp').with({ 'name' => 'rubygem-stomp' })
+    end
+  end
+  describe 'templated server.cfg' do
+    context 'With default activemq_base64 parameter (undef)' do
+      it 'should NOT contain plugin.activemq.base64 configuration' do
+        content = catalogue.resource('file', '/etc/puppetlabs/mcollective/server.cfg').send(:parameters)[:content]
+        expect(content).not_to include('plugin.activemq.base64')
+      end
+    end
+    context 'With activemq_base64 parameter set to true' do
+      let(:pre_condition) {
+        'class { "mcollective":
+          hosts           => ["middleware.example.net"],
+          client_password => "fakeTestingClientPassword",
+          server_password => "fakeTestingServerPassword",
+          psk_key         => "fakeTestingPreSharedKey",
+          activemq_base64 => true,
+        }'
+      }
+      it 'should contain plugin.activemq.base64 = yes' do
+        content = catalogue.resource('file', '/etc/puppetlabs/mcollective/server.cfg').send(:parameters)[:content]
+        expect(content).to match(/^plugin\.activemq\.base64 = yes$/)
+      end
+    end
+    context 'With activemq_base64 parameter set to false' do
+      let(:pre_condition) {
+        'class { "mcollective":
+          hosts           => ["middleware.example.net"],
+          client_password => "fakeTestingClientPassword",
+          server_password => "fakeTestingServerPassword",
+          psk_key         => "fakeTestingPreSharedKey",
+          activemq_base64 => false,
+        }'
+      }
+      it 'should contain plugin.activemq.base64 = no' do
+        content = catalogue.resource('file', '/etc/puppetlabs/mcollective/server.cfg').send(:parameters)[:content]
+        expect(content).to match(/^plugin\.activemq\.base64 = no$/)
+      end
     end
   end
 end

--- a/templates/client.cfg.erb
+++ b/templates/client.cfg.erb
@@ -14,6 +14,12 @@ connector = <%= scope.lookupvar('mcollective::connector') %>
 plugin.rabbitmq.vhost = /mcollective
 <% elsif( scope.lookupvar('mcollective::connector') == 'activemq' ) then -%>
 plugin.activemq.heartbeat_interval = 30
+<% if( scope.lookupvar('mcollective::activemq_base64') ) then -%>
+plugin.activemq.base64 = yes
+<% end -%>
+<% if( scope.lookupvar('mcollective::activemq_base64') == false ) then -%>
+plugin.activemq.base64 = no
+<% end -%>
 <% end -%>
 plugin.<%= scope.lookupvar('mcollective::connector') -%>.pool.size = <%= @hosts.length %>
 <% @hosts.each_with_index do |mqhost, index| -%>

--- a/templates/server.cfg.erb
+++ b/templates/server.cfg.erb
@@ -17,6 +17,12 @@ connector = <%= scope.lookupvar('mcollective::connector') %>
 plugin.rabbitmq.vhost = /mcollective
 <% elsif( scope.lookupvar('mcollective::connector') == 'activemq' ) then -%>
 plugin.activemq.heartbeat_interval = 30
+<% if( scope.lookupvar('mcollective::activemq_base64') ) then -%>
+plugin.activemq.base64 = yes
+<% end -%>
+<% if( scope.lookupvar('mcollective::activemq_base64') == false) then -%>
+plugin.activemq.base64 = no
+<% end -%>
 <% end -%>
 plugin.<%= scope.lookupvar('mcollective::connector') -%>.pool.size = <%= @hosts.length %>
 <% @hosts.each_with_index do |mqhost, index| -%>


### PR DESCRIPTION
Adds a new activemq_base64 parameter that defaults to undef and changes
nothing.

If set to true/false adds plugin.activemq.base64 = yes/no to server.cfg
and/or client.cfg mcollective configuration files.

In practice, users will probably only ever set the parameter to true as
the mcollective default is plugin.activemq.base64 = no if not specified.
