### PR TITLE
Add `puppet_agent_command` parameter to server.pp

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ gem 'puppet', puppetversion
 gem 'puppetlabs_spec_helper', '>= 0.1.0'
 gem 'puppet-lint', '>= 0.3.2'
 gem 'facter', '>= 1.7.0'
-gem 'rspec-puppet', '~> 2.1.0'
+gem 'rspec-puppet'
 
 # rspec must be v3.1.0 for ruby 1.8.7
 if RUBY_VERSION >= '1.8.7' and RUBY_VERSION < '1.9'

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -84,4 +84,11 @@ class mcollective::params {
     /(?i-mx:freebsd)/ => undef,
     default           => undef,
   }
+
+  # mcollective-puppet-agent settings
+  if getvar('::aio_agent_version') {
+    $puppet_agent_command = '/opt/puppetlabs/bin/puppet agent'
+  } else {
+    $puppet_agent_command = 'puppet agent'
+  }
 }

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -52,6 +52,10 @@
 #   If whitelist is empty, which resources should be blocked?
 #   Default: null
 #
+# [*puppet_agent_command*]
+#   Configures the mcollective-puppet-agent 'plugin.puppet.command' parameter.
+#   Default: 'puppet agent' or '/opt/puppetlabs/bin/puppet agent' if an AIO puppet agent package is installed.
+#
 # [*audit_logfile*]
 #   If this logfile is specified then auditing is enabled.
 #
@@ -153,13 +157,16 @@ class mcollective::server(
   $collectives                  = $mcollective::collectives,
 
   # Authorization
-  $allow_managed_resources      = true,
-  $resource_type_whitelist      = 'none',
-  $resource_type_blacklist      = undef,
   $audit_logfile                = undef,
   $authorization_enable         = undef,
   $authorization_default_policy = undef,
   $ssh_authorized_keys          = undef,
+
+  # mcollective-puppet-agent settings
+  $allow_managed_resources      = true,
+  $resource_type_whitelist      = 'none',
+  $resource_type_blacklist      = undef,
+  $puppet_agent_command         = $mcollective::params::puppet_agent_command,
 
   # Logging
   $logrotate_directory          = $mcollective::params::logrotate_directory,
@@ -177,6 +184,7 @@ class mcollective::server(
   validate_re( $version, '^present$|^latest$|^[._0-9a-zA-Z:-]+$' )
   validate_re( $ensure, '^running$|^stopped$' )
   validate_bool( $enable )
+  validate_string( $puppet_agent_command )
 
   # Validate that server username and password were supplied
   validate_re( $server_user, '^.{5}', 'Please provide a server username' )

--- a/templates/server.cfg.erb
+++ b/templates/server.cfg.erb
@@ -67,6 +67,7 @@ factsource = yaml
 plugin.yaml = <%= scope.lookupvar('mcollective::etcdir') %>/facts.yaml
 
 # Puppet resource control
+plugin.puppet.command = <%= @puppet_agent_command %>
 plugin.puppet.resource_allow_managed_resources = <%= @allow_managed_resources %>
 <% if( @resource_type_whitelist ) then -%>
 plugin.puppet.resource_type_whitelist = <%= @resource_type_whitelist %>


### PR DESCRIPTION
With the current released version of mcollective-puppet-agent plugin
this is necessary when using puppet 4 AIO packages.
