### PR TITLE
Fix FreeBSD support

### DIFF
--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -149,9 +149,7 @@ inherits mcollective {
   validate_re( $client_user, '^.{5}', 'Please provide a client username' )
   validate_re( $client_password, '^.{12}', 'Please provide at last twelve characters in client password' )
 
-  package { $package:
-    ensure  => $version,
-  }
+  ensure_packages([$package], {'ensure' => $version})
 
   file { "${etcdir}/client.cfg":
     ensure  => file,

--- a/manifests/middleware.pp
+++ b/manifests/middleware.pp
@@ -209,7 +209,7 @@ class mcollective::middleware(
     notify  => Service[ $service ],
   }
 
-  if( ( $mcollective::connector == 'activemq' ) and ( $defaults_file != '' ) ) {
+  if( ( $mcollective::connector == 'activemq' ) and ( $defaults_file != '' and $defaults_file != undef ) ) {
     file { '/etc/sysconfig/activemq':
       ensure  => file,
       owner   => $user,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -5,7 +5,10 @@
 class mcollective::params {
   # Default locations for certain os combinations
   $etcdir = $::clientversion ? {
-    /(?:4\.)/  => '/etc/puppetlabs/mcollective',
+    /(?:4\.)/  => $::osfamily ? {
+      /(?i-mx:freebsd)/ => '/usr/local/etc/mcollective',
+      default           => '/etc/puppetlabs/mcollective',
+    },
     default    => $::osfamily ? {
       /(?i-mx:redhat)/  => '/etc/mcollective',
       /(?i-mx:debian)/  => '/etc/mcollective',
@@ -45,7 +48,7 @@ class mcollective::params {
   $client_package_name = $::osfamily ? {
     /(?i-mx:redhat)/  => 'mcollective-client',
     /(?i-mx:debian)/  => 'mcollective-client',
-    /(?i-mx:freebsd)/ => 'sysutils/mcollective-client',
+    /(?i-mx:freebsd)/ => 'sysutils/mcollective',
     default           => 'mcollective-client',
   }
 

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -186,10 +186,7 @@ class mcollective::server(
   include mcollective::facts::cronjob
 
   # Now install the packages
-  package { $package:
-    ensure => $version,
-    notify => Service[ $service ],
-  }
+  ensure_packages([$package], {'ensure' => $version})
 
   file { "${etcdir}/server.cfg":
     ensure  => file,
@@ -296,9 +293,9 @@ class mcollective::server(
 
   # Now start the daemon
   service { $service:
-    ensure  => $ensure,
-    enable  => $enable,
-    require => Package[ $package ],
+    ensure    => $ensure,
+    enable    => $enable,
+    subscribe => Package[ $package ],
   }
 
   # Load in all the appropriate mcollective agents


### PR DESCRIPTION
 - Change client package name from `sysutils/mcollective-client` to `sysutils/mcollective`
 - Handle that FreeBSD client and server is in the same package
 - Change etc dir for Puppet client version 4 from `/etc/puppetlabs/mcollective` to `/usr/local/etc/mcollective`
 - Ignore sysconfig when `$mcollective::middleware::defaults_file` is `undef`